### PR TITLE
Importing d3.mouse via module instead of via <script/> reference on m…

### DIFF
--- a/src/comparison/apiRender.js
+++ b/src/comparison/apiRender.js
@@ -23,8 +23,7 @@ const apiRender = state => ({
 
     selection
       .on('mousemove.comparison', function() {
-        // todo, why directly d3.mouse doesn't work?
-        context.focus(Math.round(d3.mouse(this)[0]));
+        context.focus(Math.round(mouse(this)[0]));
       })
       .on('mouseout.comparison', () => context.focus(null));
 

--- a/src/horizon/apiRender.js
+++ b/src/horizon/apiRender.js
@@ -1,4 +1,4 @@
-import { select } from 'd3-selection';
+import { select, mouse } from 'd3-selection';
 
 const apiRender = (context, state) => ({
   render: selection => {
@@ -18,8 +18,7 @@ const apiRender = (context, state) => ({
 
     selection
       .on('mousemove.horizon', function() {
-        // todo: why directly importing mouse doesn't work here?
-        context.focus(Math.round(d3.mouse(this)[0]));
+        context.focus(Math.round(mouse(this)[0]));
       })
       .on('mouseout.horizon', () => context.focus(null));
 


### PR DESCRIPTION
I use the cubism esm module now via a React useEffect hook. When import the mouse function via the module system, it doesn't throw anymore.