### PR TITLE
Importing mouse from 'd3' module, removing 'arguments'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+dist

--- a/src/comparison/apiRender.js
+++ b/src/comparison/apiRender.js
@@ -1,4 +1,5 @@
-import { mouse, select } from 'd3-selection';
+import { select } from 'd3-selection';
+import { mouse } from 'd3';
 import uuid from '../uuid';
 
 const roundEven = i => i & 0xfffffe;
@@ -23,8 +24,7 @@ const apiRender = state => ({
 
     selection
       .on('mousemove.comparison', function() {
-        // todo, why directly d3.mouse doesn't work?
-        context.focus(Math.round(d3.mouse(this)[0]));
+        context.focus(Math.round(mouse(this)[0]));
       })
       .on('mouseout.comparison', () => context.focus(null));
 

--- a/src/horizon/apiRender.js
+++ b/src/horizon/apiRender.js
@@ -1,4 +1,5 @@
 import { select } from 'd3-selection';
+import { mouse } from 'd3';
 
 const apiRender = (context, state) => ({
   render: selection => {
@@ -19,7 +20,8 @@ const apiRender = (context, state) => ({
     selection
       .on('mousemove.horizon', function() {
         // todo: why directly importing mouse doesn't work here?
-        context.focus(Math.round(d3.mouse(this)[0]));
+        // TODO
+        context.focus(Math.round(mouse(this)[0]));
       })
       .on('mouseout.horizon', () => context.focus(null));
 

--- a/src/horizon/apiRender.js
+++ b/src/horizon/apiRender.js
@@ -19,8 +19,6 @@ const apiRender = (context, state) => ({
 
     selection
       .on('mousemove.horizon', function() {
-        // todo: why directly importing mouse doesn't work here?
-        // TODO
         context.focus(Math.round(mouse(this)[0]));
       })
       .on('mouseout.horizon', () => context.focus(null));

--- a/src/option.js
+++ b/src/option.js
@@ -10,7 +10,7 @@ const options = (name, defaultValues) => {
       values.push(decodeURIComponent(o[1]));
     }
   }
-  return values.length || arguments.length < 2 ? values : defaultValues;
+  return values.length || !defaultValues ? values : defaultValues;
 };
 
 const option = (name, defaultValue) => {


### PR DESCRIPTION
It seems I've found the solution for the mouse issue, it should be imported from `d3` instead of `d3-selection` and then it works (for me). (See #5 )
I've also replaced the `arguments.length` check in `options.js` since `arguments` is not available inside arrow functions.